### PR TITLE
Increase FTP transfer speed by setting FTP client buffer size

### DIFF
--- a/app/src/main/java/org/bostwickenator/ftpuploader/FtpClient.java
+++ b/app/src/main/java/org/bostwickenator/ftpuploader/FtpClient.java
@@ -54,6 +54,7 @@ class FtpClient {
     }
 
     public boolean storeFile(File file) throws IOException {
+        this.ftpClient.setBufferSize(1024 * 1024 * 8);
         FileInputStream fis = new FileInputStream(file);
         boolean result = this.ftpClient.storeFile(file.getName(), fis);
         fis.close();


### PR DESCRIPTION
I was getting slow transfer speeds (< 1MB/s). Saw this [answer](https://stackoverflow.com/a/19063119) about increasing Apache FTP client transfer speed. I set the buffer to 8MB (16MB would cause the camera to crash), which increased the transfer speed to roughly 1.7MB/S